### PR TITLE
Add verification IP for firewalling purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Attributes
 * `node['letsencrypt']['contact']` - Contact information, default empty. Set to `mailto:your@email.com`.
 * `node['letsencrypt']['endpoint']` - ACME server endpoint, default `https://acme-staging.api.letsencrypt.org`. Set to `https://acme-v01.api.letsencrypt.org` for real certificates.
 * `node['letsencrypt']['renew']` - Days before the certificate expires at which the certificate will be renewed, default `30`.
+* `node['letsencrypt']['source_ips']` - IP addresses used by letsencrypt to verify the TLS certificates. This attribute is for firewall purposes. Allow these IPs for HTTP (tcp/80).
 
 Recipes
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,5 +21,7 @@
 default['letsencrypt']['contact']     = []
 default['letsencrypt']['endpoint']    = 'https://acme-staging.api.letsencrypt.org'
 default['letsencrypt']['renew']       = 30
+default['letsencrypt']['source_ips']  = ['66.133.109.36']
 
 default['letsencrypt']['private_key'] = nil
+


### PR DESCRIPTION
If you run a lot of web apps in a firewalled environment, it's nice to be able to open up a http port specifically for verification. This is the IP that let's encrypt currently uses for verification. It might change over time. It might become multiple. That's why I made it an array.