### PR TITLE
Wrap test cookbooks in :integration group

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,8 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'acme_client', path: 'test/fixtures/cookbooks/acme_client'
-cookbook 'acme_server', path: 'test/fixtures/cookbooks/acme_server'
+group :integration do
+  cookbook 'acme_client', path: 'test/fixtures/cookbooks/acme_client'
+  cookbook 'acme_server', path: 'test/fixtures/cookbooks/acme_server'
+end
 
 metadata


### PR DESCRIPTION
This way it is possible to do a 'berks upload -e integration' to upload the cookbook and all it's dependencies to a chef server, but leaving out the test cookbook.